### PR TITLE
feat: initialize slider position based on existing bookmarks (#240)

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/simolus3/CSQLite.git",
       "state" : {
-        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+        "revision" : "1ee46d19a4f451a7aa64ffc64fc99b4748131e62"
       }
     },
     {
@@ -31,8 +31,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "45210bd1ea695779e6de016ab00fea8c0b7eb2ef",
-        "version" : "12.7.0"
+        "revision" : "46579c364d39b86ec9fb8f613e19f023700a929c",
+        "version" : "12.12.1"
       }
     },
     {
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/flutterfire",
       "state" : {
-        "revision" : "39bdb5b1ef392e8c31c60209e333b45e408099e8",
-        "version" : "4.3.0-firebase-core-swift"
+        "revision" : "a10a4148e769fadb01b1ff8d6bb76e9137f35b81",
+        "version" : "4.6.0-firebase-core-swift"
       }
     },
     {
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "35b601a60fbbea2de3ea461f604deaaa4d8bbd0c",
-        "version" : "3.2.0"
+        "revision" : "19dffda9a9caf8d86570ff846535902d8509d7bf",
+        "version" : "3.5.0"
       }
     },
     {
@@ -58,8 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "c2d59acf17a8ba7ed80a763593c67c9c7c006ad1",
-        "version" : "12.5.0"
+        "revision" : "5100f946bd32778662047a823bf145c6da32d85d",
+        "version" : "12.12.1"
       }
     },
     {
@@ -132,15 +132,6 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "c169a5744230951031770e27e475ff6eefe51f9d",
-        "version" : "1.33.3"
       }
     }
   ],

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/simolus3/CSQLite.git",
       "state" : {
-        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+        "revision" : "1ee46d19a4f451a7aa64ffc64fc99b4748131e62"
       }
     },
     {
@@ -31,8 +31,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "45210bd1ea695779e6de016ab00fea8c0b7eb2ef",
-        "version" : "12.7.0"
+        "revision" : "46579c364d39b86ec9fb8f613e19f023700a929c",
+        "version" : "12.12.1"
       }
     },
     {
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/flutterfire",
       "state" : {
-        "revision" : "39bdb5b1ef392e8c31c60209e333b45e408099e8",
-        "version" : "4.3.0-firebase-core-swift"
+        "revision" : "a10a4148e769fadb01b1ff8d6bb76e9137f35b81",
+        "version" : "4.6.0-firebase-core-swift"
       }
     },
     {
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "35b601a60fbbea2de3ea461f604deaaa4d8bbd0c",
-        "version" : "3.2.0"
+        "revision" : "19dffda9a9caf8d86570ff846535902d8509d7bf",
+        "version" : "3.5.0"
       }
     },
     {
@@ -58,8 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "c2d59acf17a8ba7ed80a763593c67c9c7c006ad1",
-        "version" : "12.5.0"
+        "revision" : "5100f946bd32778662047a823bf145c6da32d85d",
+        "version" : "12.12.1"
       }
     },
     {
@@ -132,15 +132,6 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "c169a5744230951031770e27e475ff6eefe51f9d",
-        "version" : "1.33.3"
       }
     }
   ],

--- a/lib/components/material_slider.dart
+++ b/lib/components/material_slider.dart
@@ -3,7 +3,6 @@ import "package:flutter/material.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 
-import "../composables/use_list_state.dart";
 import "../core/asset_cache.dart";
 import "../models/character.dart";
 import "../models/common.dart";
@@ -34,6 +33,8 @@ class MaterialSlider extends HookConsumerWidget {
     this.labelBuilder,
     this.lackNums,
     required this.onRangesChanged,
+    this.expandedPurposes,
+    this.onExpansionChanged,
   });
 
   final IngredientConfigurations ingredientConf;
@@ -46,23 +47,14 @@ class MaterialSlider extends HookConsumerWidget {
   final LabelWidgetBuilder? labelBuilder;
   final ValueChanged<Map<Purpose, LevelRangeValues>> onRangesChanged;
   final ItemLackNums? lackNums;
+  final Set<Purpose>? expandedPurposes;
+  final void Function(Purpose purpose, bool expanded)? onExpansionChanged;
 
   bool get showActiveCheckbox => purposes.length >= 2;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final assetData = ref.watch(assetDataProvider).value!;
-
-    final activeSliders = useListState<Purpose>(purposes);
-
-    useEffect(() {
-      ranges.forEach((k, v) {
-        if (showActiveCheckbox && v.start == v.end) {
-          activeSliders.remove(k);
-        }
-      });
-      return null;
-    }, [ranges]);
 
     return Column(
       spacing: 8,
@@ -71,13 +63,9 @@ class MaterialSlider extends HookConsumerWidget {
         for (final purpose in purposes)
           _buildSliderContainer(
             purpose: purpose,
-            active: activeSliders.contains(purpose),
+            active: expandedPurposes?.contains(purpose) ?? false,
             onActiveChanged: (active) {
-              if (active) {
-                activeSliders.add(purpose);
-              } else {
-                activeSliders.remove(purpose);
-              }
+              onExpansionChanged?.call(purpose, active);
             },
             child: _buildSlider(
               purpose: purpose,
@@ -93,7 +81,7 @@ class MaterialSlider extends HookConsumerWidget {
         Wrap(
           children: _buildMaterialCards(
             assetData: assetData,
-            activeSliders: activeSliders,
+            activeSliders: expandedPurposes ?? {},
           ),
         ),
       ],
@@ -163,7 +151,7 @@ class MaterialSlider extends HookConsumerWidget {
 
   List<Widget> _buildMaterialCards({
     required AssetData assetData,
-    required List<Purpose> activeSliders,
+    required Set<Purpose> activeSliders,
   }) {
     final fullQuantities = useMemoized(
       () => _calculateFullQuantities(assetData),

--- a/lib/db/bookmark_db_extension.dart
+++ b/lib/db/bookmark_db_extension.dart
@@ -1,4 +1,6 @@
 
+import "dart:math";
+
 import "package:drift/drift.dart";
 
 import "../database.dart";
@@ -118,6 +120,54 @@ extension BookmarkDbExtension on AppDatabase {
         );
       }).toList();
     });
+  }
+
+  /// Returns the min/max upperLevel per purpose for character material bookmarks (no weapon).
+  Future<Map<Purpose, ({int minUpperLevel, int maxUpperLevel})>> getCharacterMaterialBookmarkLevelRanges(String characterId) async {
+    final query = select(bookmarkTable).join([
+      leftOuterJoin(bookmarkMaterialDetailsTable, bookmarkMaterialDetailsTable.parentId.equalsExp(bookmarkTable.id)),
+    ]);
+    query.where(
+      bookmarkTable.characterId.equals(characterId) &
+      bookmarkTable.type.equalsValue(BookmarkType.material) &
+      bookmarkMaterialDetailsTable.weaponId.isNull(),
+    );
+    final rows = await query.get();
+    return _aggregateBookmarkLevelRanges(rows);
+  }
+
+  /// Returns the min/max upperLevel per purpose for weapon material bookmarks.
+  Future<Map<Purpose, ({int minUpperLevel, int maxUpperLevel})>> getWeaponMaterialBookmarkLevelRanges(String weaponId) async {
+    final query = select(bookmarkTable).join([
+      leftOuterJoin(bookmarkMaterialDetailsTable, bookmarkMaterialDetailsTable.parentId.equalsExp(bookmarkTable.id)),
+    ]);
+    query.where(
+      bookmarkTable.type.equalsValue(BookmarkType.material) &
+      bookmarkMaterialDetailsTable.weaponId.equals(weaponId),
+    );
+    final rows = await query.get();
+    return _aggregateBookmarkLevelRanges(rows);
+  }
+
+  Map<Purpose, ({int minUpperLevel, int maxUpperLevel})> _aggregateBookmarkLevelRanges(
+    List<TypedResult> rows,
+  ) {
+    final result = <Purpose, ({int minUpperLevel, int maxUpperLevel})>{};
+    for (final row in rows) {
+      final details = row.readTable(bookmarkMaterialDetailsTable);
+      final purpose = details.purposeType;
+      final upperLevel = details.upperLevel;
+      if (result.containsKey(purpose)) {
+        final current = result[purpose]!;
+        result[purpose] = (
+          minUpperLevel: min(current.minUpperLevel, upperLevel),
+          maxUpperLevel: max(current.maxUpperLevel, upperLevel),
+        );
+      } else {
+        result[purpose] = (minUpperLevel: upperLevel, maxUpperLevel: upperLevel);
+      }
+    }
+    return result;
   }
 
   Future<void> _addBookmarks(List<BookmarkInsertable> insertables) async {

--- a/lib/db/bookmark_db_extension.dart
+++ b/lib/db/bookmark_db_extension.dart
@@ -122,12 +122,13 @@ extension BookmarkDbExtension on AppDatabase {
     });
   }
 
+  JoinedSelectStatement<HasResultSet, dynamic> _createMaterialBookmarkQuery() => select(bookmarkTable).join([
+    leftOuterJoin(bookmarkMaterialDetailsTable, bookmarkMaterialDetailsTable.parentId.equalsExp(bookmarkTable.id)),
+  ]);
+
   /// Returns the min/max upperLevel per purpose for character material bookmarks (no weapon).
   Future<Map<Purpose, ({int minUpperLevel, int maxUpperLevel})>> getCharacterMaterialBookmarkLevelRanges(String characterId) async {
-    final query = select(bookmarkTable).join([
-      leftOuterJoin(bookmarkMaterialDetailsTable, bookmarkMaterialDetailsTable.parentId.equalsExp(bookmarkTable.id)),
-    ]);
-    query.where(
+    final query = _createMaterialBookmarkQuery()..where(
       bookmarkTable.characterId.equals(characterId) &
       bookmarkTable.type.equalsValue(BookmarkType.material) &
       bookmarkMaterialDetailsTable.weaponId.isNull(),
@@ -138,10 +139,7 @@ extension BookmarkDbExtension on AppDatabase {
 
   /// Returns the min/max upperLevel per purpose for weapon material bookmarks.
   Future<Map<Purpose, ({int minUpperLevel, int maxUpperLevel})>> getWeaponMaterialBookmarkLevelRanges(String weaponId) async {
-    final query = select(bookmarkTable).join([
-      leftOuterJoin(bookmarkMaterialDetailsTable, bookmarkMaterialDetailsTable.parentId.equalsExp(bookmarkTable.id)),
-    ]);
-    query.where(
+    final query = _createMaterialBookmarkQuery()..where(
       bookmarkTable.type.equalsValue(BookmarkType.material) &
       bookmarkMaterialDetailsTable.weaponId.equals(weaponId),
     );

--- a/lib/db/bookmark_db_extension.dart
+++ b/lib/db/bookmark_db_extension.dart
@@ -1,4 +1,3 @@
-
 import "dart:math";
 
 import "package:drift/drift.dart";
@@ -126,7 +125,8 @@ extension BookmarkDbExtension on AppDatabase {
     leftOuterJoin(bookmarkMaterialDetailsTable, bookmarkMaterialDetailsTable.parentId.equalsExp(bookmarkTable.id)),
   ]);
 
-  /// Returns the min/max upperLevel per purpose for character material bookmarks (no weapon).
+  /// Returns the min/max upperLevel per purpose for character material
+  /// bookmarks (no weapon).
   Future<Map<Purpose, ({int minUpperLevel, int maxUpperLevel})>> getCharacterMaterialBookmarkLevelRanges(String characterId) async {
     final query = _createMaterialBookmarkQuery()..where(
       bookmarkTable.characterId.equals(characterId) &

--- a/lib/pages/database/characters/character_details.dart
+++ b/lib/pages/database/characters/character_details.dart
@@ -62,8 +62,13 @@ class CharacterDetailsPage extends HookConsumerWidget {
         : Future.value(null));
     final csSnapshot = useFuture(csResult);
 
+    final bookmarkRangesResult = useMemoized(
+        () => db.getCharacterMaterialBookmarkLevelRanges(character.id));
+    final bookmarkRangesSnapshot = useFuture(bookmarkRangesResult);
+
     // loading
-    if (uid != null && syncCharaState && csSnapshot.connectionState != ConnectionState.done) {
+    if (bookmarkRangesSnapshot.connectionState != ConnectionState.done ||
+        (uid != null && syncCharaState && csSnapshot.connectionState != ConnectionState.done)) {
       return Scaffold(
         appBar: AppBar(),
         body: const Center(child: CircularProgressIndicator()),
@@ -75,6 +80,7 @@ class CharacterDetailsPage extends HookConsumerWidget {
       assetData: assetData,
       initialVariant: characterOrVariant is CharacterVariant ? characterOrVariant.element : null,
       initialCharacterState: csSnapshot.data,
+      initialBookmarkRanges: bookmarkRangesSnapshot.data ?? {},
     );
   }
 }
@@ -84,12 +90,14 @@ class _CharacterDetailsPageContents extends HookConsumerWidget {
   final AssetData assetData;
   final String? initialVariant;
   final InGameCharacterState? initialCharacterState;
+  final Map<Purpose, ({int minUpperLevel, int maxUpperLevel})> initialBookmarkRanges;
 
   const _CharacterDetailsPageContents({
     required this.character,
     required this.assetData,
     this.initialVariant,
     this.initialCharacterState,
+    this.initialBookmarkRanges = const {},
   });
 
   @override
@@ -100,6 +108,7 @@ class _CharacterDetailsPageContents extends HookConsumerWidget {
       ingredients: assetData.characterIngredients,
       rarity: character.rarity,
       initialCharacterState: initialCharacterState,
+      bookmarkRanges: initialBookmarkRanges,
     )));
 
     final ingredients = assetData.characterIngredients;
@@ -397,6 +406,7 @@ sealed class _CharacterDetailsPageState with _$CharacterDetailsPageState {
     required IngredientConfigurations ingredients,
     required int rarity,
     InGameCharacterState? initialCharacterState,
+    Map<Purpose, ({int minUpperLevel, int maxUpperLevel})> bookmarkRanges = const {},
   }) {
     final rangeValues = <Purpose, LevelRangeValues>{};
     final checkedTalentTypes = <Purpose, bool>{};
@@ -404,10 +414,25 @@ sealed class _CharacterDetailsPageState with _$CharacterDetailsPageState {
 
     for (final purpose in ingredients.rarities[rarity]!.purposes.keys) {
       final levels = ingredients.getLevels(rarity: rarity, purpose: purpose).levels;
-      final initialSliderLowerRange = initialCharacterState?.purposes[purpose] ?? 1;
+      final levelTicks = levels.keys.toList();
+      final characterCurrentLevel = initialCharacterState?.purposes[purpose] ?? 1;
 
-      rangeValues[purpose] = LevelRangeValues(initialSliderLowerRange, levels.keys.last);
-      checkedTalentTypes[purpose] = initialSliderLowerRange < levels.keys.last;
+      int start;
+      int end;
+
+      if (bookmarkRanges.containsKey(purpose)) {
+        final range = bookmarkRanges[purpose]!;
+        final minUpperLevelIndex = levelTicks.indexOf(range.minUpperLevel);
+        final bookmarkStart = minUpperLevelIndex >= 1 ? levelTicks[minUpperLevelIndex - 1] : 1;
+        start = max(characterCurrentLevel, bookmarkStart);
+        end = range.maxUpperLevel;
+      } else {
+        start = characterCurrentLevel;
+        end = levels.keys.last;
+      }
+
+      rangeValues[purpose] = LevelRangeValues(start, end);
+      checkedTalentTypes[purpose] = start < levels.keys.last;
       talentSectionKeys[purpose] = GlobalKey();
     }
 

--- a/lib/pages/database/characters/character_details.dart
+++ b/lib/pages/database/characters/character_details.dart
@@ -147,10 +147,15 @@ class _CharacterDetailsPageContents extends HookConsumerWidget {
         var newState = state.value;
         if (result.value!.levels != null) {
           for (final e in result.value!.levels!.entries) {
-            final ingLevels = ingredients.getLevels(rarity: character.rarity, purpose: e.key);newState = newState.copyWith(
+            final ingLevels = ingredients.getLevels(rarity: character.rarity, purpose: e.key);
+            newState = newState.copyWith(
               rangeValues: {...newState.rangeValues}..[e.key] = LevelRangeValues(e.value, max(e.value, newState.rangeValues[e.key]!.end)),
-              checkedTalentTypes: {...newState.checkedTalentTypes}..[e.key] = e.value < ingLevels.levels.keys.last,
             );
+            if (e.value == ingLevels.levels.keys.last) {
+              newState = newState.copyWith(
+                checkedTalentTypes: {...newState.checkedTalentTypes}..[e.key] = false,
+              );
+            }
           }
 
           if (prefs.autoRemoveBookmarks) {
@@ -330,6 +335,13 @@ class _CharacterDetailsPageContents extends HookConsumerWidget {
                         ingredientConf: ingredients,
                         purposes: slider.purposes,
                         lackNums: lackNums,
+                        // TODO: make checkedTalentTypes set of [Purpose]
+                        expandedPurposes: state.value.checkedTalentTypes.entries.where((e) => e.value).map((e) => e.key).toSet(),
+                        onExpansionChanged: (purpose, expanded) {
+                          state.value = state.value.copyWith(
+                            checkedTalentTypes: {...state.value.checkedTalentTypes}..[purpose] = expanded,
+                          );
+                        },
                         target: switch (slider.preferredTargetType) {
                           PreferredTargetType.group => character,
                           PreferredTargetType.variant || null => variant.value,
@@ -426,10 +438,21 @@ sealed class _CharacterDetailsPageState with _$CharacterDetailsPageState {
       } else {
         range = LevelRangeValues(characterCurrentLevel, levels.keys.last);
       }
+      if (purpose != .ascension) {
+        checkedTalentTypes[purpose] = range.start < levels.keys.last;
+      }
 
       rangeValues[purpose] = range;
-      checkedTalentTypes[purpose] = range.start < levels.keys.last;
       talentSectionKeys[purpose] = GlobalKey();
+    }
+
+    // Slider is initially closed if there are talent bookmarks and this
+    // purpose is not bookmarked
+    final talents = {Purpose.normalAttack, Purpose.elementalSkill, Purpose.elementalBurst};
+    if (talents.any((e) => bookmarkRanges.containsKey(e))) {
+      for (var purpose in talents) {
+        checkedTalentTypes[purpose] = bookmarkRanges.containsKey(purpose);
+      }
     }
 
     return _CharacterDetailsPageState(

--- a/lib/pages/database/characters/character_details.dart
+++ b/lib/pages/database/characters/character_details.dart
@@ -417,22 +417,18 @@ sealed class _CharacterDetailsPageState with _$CharacterDetailsPageState {
       final levelTicks = levels.keys.toList();
       final characterCurrentLevel = initialCharacterState?.purposes[purpose] ?? 1;
 
-      int start;
-      int end;
-
+      final LevelRangeValues range;
       if (bookmarkRanges.containsKey(purpose)) {
-        final range = bookmarkRanges[purpose]!;
-        final minUpperLevelIndex = levelTicks.indexOf(range.minUpperLevel);
-        final bookmarkStart = minUpperLevelIndex >= 1 ? levelTicks[minUpperLevelIndex - 1] : 1;
-        start = max(characterCurrentLevel, bookmarkStart);
-        end = range.maxUpperLevel;
+        final bookmark = bookmarkRanges[purpose]!;
+        final minUpperLevelIndex = levelTicks.indexOf(bookmark.minUpperLevel);
+        final start = minUpperLevelIndex >= 1 ? levelTicks[minUpperLevelIndex - 1] : 1;
+        range = LevelRangeValues(start, bookmark.maxUpperLevel);
       } else {
-        start = characterCurrentLevel;
-        end = levels.keys.last;
+        range = LevelRangeValues(characterCurrentLevel, levels.keys.last);
       }
 
-      rangeValues[purpose] = LevelRangeValues(start, end);
-      checkedTalentTypes[purpose] = start < levels.keys.last;
+      rangeValues[purpose] = range;
+      checkedTalentTypes[purpose] = range.start < levels.keys.last;
       talentSectionKeys[purpose] = GlobalKey();
     }
 

--- a/lib/pages/database/characters/character_details.dart
+++ b/lib/pages/database/characters/character_details.dart
@@ -433,7 +433,7 @@ sealed class _CharacterDetailsPageState with _$CharacterDetailsPageState {
       if (bookmarkRanges.containsKey(purpose)) {
         final bookmark = bookmarkRanges[purpose]!;
         final minUpperLevelIndex = levelTicks.indexOf(bookmark.minUpperLevel);
-        final start = minUpperLevelIndex >= 1 ? levelTicks[minUpperLevelIndex - 1] : 1;
+        final start = minUpperLevelIndex >= 1 ? levelTicks[minUpperLevelIndex - 1] : levelTicks.first;
         range = LevelRangeValues(start, bookmark.maxUpperLevel);
       } else {
         range = LevelRangeValues(characterCurrentLevel, levels.keys.last);

--- a/lib/pages/database/weapons/weapon_details.dart
+++ b/lib/pages/database/weapons/weapon_details.dart
@@ -270,12 +270,12 @@ sealed class _WeaponDetailsPageState with _$WeaponDetailsPageState {
     );
     final levelTicks = levelsEntry.levels.keys.toList();
 
-    LevelRangeValues ascensionRange;
+    final LevelRangeValues ascensionRange;
     if (bookmarkRanges.containsKey(Purpose.ascension)) {
-      final range = bookmarkRanges[Purpose.ascension]!;
-      final minUpperLevelIndex = levelTicks.indexOf(range.minUpperLevel);
-      final bookmarkStart = minUpperLevelIndex >= 1 ? levelTicks[minUpperLevelIndex - 1] : 1;
-      ascensionRange = LevelRangeValues(bookmarkStart, range.maxUpperLevel);
+      final bookmark = bookmarkRanges[Purpose.ascension]!;
+      final minUpperLevelIndex = levelTicks.indexOf(bookmark.minUpperLevel);
+      final start = minUpperLevelIndex >= 1 ? levelTicks[minUpperLevelIndex - 1] : 1;
+      ascensionRange = LevelRangeValues(start, bookmark.maxUpperLevel);
     } else {
       ascensionRange = LevelRangeValues(1, levelTicks.last);
     }

--- a/lib/pages/database/weapons/weapon_details.dart
+++ b/lib/pages/database/weapons/weapon_details.dart
@@ -17,9 +17,11 @@ import "../../../components/material_slider.dart";
 import "../../../components/rarity_stars.dart";
 import "../../../core/asset_cache.dart";
 import "../../../database.dart";
+import "../../../db/bookmark_db_extension.dart";
 import "../../../db/in_game_weapon_state_db_extension.dart";
 import "../../../i18n/strings.g.dart";
 import "../../../models/common.dart";
+import "../../../models/ingredients.dart";
 import "../../../models/weapon.dart";
 import "../../../providers/database_provider.dart";
 import "../../../providers/game_data_sync.dart";
@@ -66,8 +68,13 @@ class WeaponDetailsPage extends HookConsumerWidget {
         : Future.value(null));
     final wsSnapshot = useFuture(wsResult);
 
+    final bookmarkRangesResult = useMemoized(
+        () => db.getWeaponMaterialBookmarkLevelRanges(id));
+    final bookmarkRangesSnapshot = useFuture(bookmarkRangesResult);
+
     // loading
-    if (uid != null && syncWeaponState && wsSnapshot.connectionState != ConnectionState.done) {
+    if (bookmarkRangesSnapshot.connectionState != ConnectionState.done ||
+        (uid != null && syncWeaponState && wsSnapshot.connectionState != ConnectionState.done)) {
       return Scaffold(
         appBar: AppBar(),
         body: const Center(child: CircularProgressIndicator()),
@@ -79,6 +86,7 @@ class WeaponDetailsPage extends HookConsumerWidget {
       assetData: assetData,
       initialSelectedCharacter: initialCharacterId,
       initialWeaponState: wsSnapshot.data,
+      initialBookmarkRanges: bookmarkRangesSnapshot.data ?? {},
     );
   }
 }
@@ -89,6 +97,7 @@ class WeaponDetailsPageContents extends HookConsumerWidget {
   final Weapon weapon;
   final CharacterId initialSelectedCharacter;
   final InGameWeaponState? initialWeaponState;
+  final Map<Purpose, ({int minUpperLevel, int maxUpperLevel})> initialBookmarkRanges;
 
   const WeaponDetailsPageContents({
     super.key,
@@ -96,19 +105,18 @@ class WeaponDetailsPageContents extends HookConsumerWidget {
     required this.assetData,
     required this.initialSelectedCharacter,
     this.initialWeaponState,
+    this.initialBookmarkRanges = const {},
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ingredients = assetData.weaponIngredients;
-    final levelsEntry = ingredients.getLevels(
-      rarity: weapon.rarity,
-      purpose: Purpose.ascension,
-    );
 
     final state = useState(_WeaponDetailsPageState.init(
-      rangeValues: LevelRangeValues(1, levelsEntry.levels.keys.last),
+      ingredients: ingredients,
+      weapon: weapon,
       selectedCharacterId: initialSelectedCharacter,
+      bookmarkRanges: initialBookmarkRanges,
     ));
 
     final characters = useMemoized(() => filterCharactersByWeaponType(assetData.characters.values, weapon.type).toList());
@@ -251,12 +259,30 @@ sealed class _WeaponDetailsPageState with _$WeaponDetailsPageState {
   }) = __WeaponDetailsPageState;
 
   factory _WeaponDetailsPageState.init({
-    required LevelRangeValues rangeValues,
+    required IngredientConfigurations ingredients,
+    required Weapon weapon,
     required CharacterId selectedCharacterId,
+    Map<Purpose, ({int minUpperLevel, int maxUpperLevel})> bookmarkRanges = const {},
   }) {
+    final levelsEntry = ingredients.getLevels(
+      rarity: weapon.rarity,
+      purpose: Purpose.ascension,
+    );
+    final levelTicks = levelsEntry.levels.keys.toList();
+
+    LevelRangeValues ascensionRange;
+    if (bookmarkRanges.containsKey(Purpose.ascension)) {
+      final range = bookmarkRanges[Purpose.ascension]!;
+      final minUpperLevelIndex = levelTicks.indexOf(range.minUpperLevel);
+      final bookmarkStart = minUpperLevelIndex >= 1 ? levelTicks[minUpperLevelIndex - 1] : 1;
+      ascensionRange = LevelRangeValues(bookmarkStart, range.maxUpperLevel);
+    } else {
+      ascensionRange = LevelRangeValues(1, levelTicks.last);
+    }
+
     return _WeaponDetailsPageState(
       rangeValues: {
-        Purpose.ascension: rangeValues,
+        Purpose.ascension: ascensionRange,
       },
       selectedCharacterId: selectedCharacterId,
     );

--- a/test/drift/db/bookmark_db_extension_test.dart
+++ b/test/drift/db/bookmark_db_extension_test.dart
@@ -1,0 +1,259 @@
+import "package:drift/native.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:genshin_material/database.dart";
+import "package:genshin_material/db/bookmark_db_extension.dart";
+import "package:genshin_material/models/bookmark.dart";
+import "package:genshin_material/models/common.dart";
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  MaterialBookmarkInsertable _makeCharacterBookmark({
+    required String characterId,
+    required Purpose purpose,
+    required int upperLevel,
+    String? materialId,
+  }) {
+    return MaterialBookmarkInsertable(
+      characterId: characterId,
+      weaponId: null,
+      materialId: materialId ?? "mat_$upperLevel",
+      quantity: 1,
+      upperLevel: upperLevel,
+      purposeType: purpose,
+    );
+  }
+
+  MaterialBookmarkInsertable _makeWeaponBookmark({
+    required String characterId,
+    required String weaponId,
+    required int upperLevel,
+    String? materialId,
+  }) {
+    return MaterialBookmarkInsertable(
+      characterId: characterId,
+      weaponId: weaponId,
+      materialId: materialId ?? "wmat_$upperLevel",
+      quantity: 1,
+      upperLevel: upperLevel,
+      purposeType: Purpose.ascension,
+    );
+  }
+
+  group("getCharacterMaterialBookmarkLevelRanges", () {
+    test("returns empty map when no bookmarks", () async {
+      final result = await db.getCharacterMaterialBookmarkLevelRanges("char_1");
+      expect(result, isEmpty);
+    });
+
+    test("returns single bookmark range correctly", () async {
+      await db.addMaterialBookmarks([
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.ascension,
+          upperLevel: 40,
+        ),
+      ]);
+
+      final result = await db.getCharacterMaterialBookmarkLevelRanges("char_1");
+
+      expect(result, hasLength(1));
+      expect(result[Purpose.ascension]!.minUpperLevel, 40);
+      expect(result[Purpose.ascension]!.maxUpperLevel, 40);
+    });
+
+    test("aggregates min/max across multiple bookmarks for same purpose",
+        () async {
+      await db.addMaterialBookmarks([
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.ascension,
+          upperLevel: 20,
+          materialId: "mat_a",
+        ),
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.ascension,
+          upperLevel: 40,
+          materialId: "mat_b",
+        ),
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.ascension,
+          upperLevel: 60,
+          materialId: "mat_c",
+        ),
+      ]);
+
+      final result = await db.getCharacterMaterialBookmarkLevelRanges("char_1");
+
+      expect(result[Purpose.ascension]!.minUpperLevel, 20);
+      expect(result[Purpose.ascension]!.maxUpperLevel, 60);
+    });
+
+    test("returns separate ranges per purpose", () async {
+      await db.addMaterialBookmarks([
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.ascension,
+          upperLevel: 40,
+          materialId: "mat_asc",
+        ),
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.normalAttack,
+          upperLevel: 6,
+          materialId: "mat_na",
+        ),
+      ]);
+
+      final result = await db.getCharacterMaterialBookmarkLevelRanges("char_1");
+
+      expect(result, hasLength(2));
+      expect(result[Purpose.ascension]!.minUpperLevel, 40);
+      expect(result[Purpose.ascension]!.maxUpperLevel, 40);
+      expect(result[Purpose.normalAttack]!.minUpperLevel, 6);
+      expect(result[Purpose.normalAttack]!.maxUpperLevel, 6);
+    });
+
+    test("does not include weapon bookmarks", () async {
+      await db.addMaterialBookmarks([
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.ascension,
+          upperLevel: 40,
+          materialId: "char_mat",
+        ),
+        _makeWeaponBookmark(
+          characterId: "char_1",
+          weaponId: "weapon_1",
+          upperLevel: 70,
+          materialId: "weapon_mat",
+        ),
+      ]);
+
+      final result = await db.getCharacterMaterialBookmarkLevelRanges("char_1");
+
+      expect(result, hasLength(1));
+      expect(result[Purpose.ascension]!.maxUpperLevel, 40);
+    });
+
+    test("does not include bookmarks for other characters", () async {
+      await db.addMaterialBookmarks([
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.ascension,
+          upperLevel: 40,
+          materialId: "mat_c1",
+        ),
+        _makeCharacterBookmark(
+          characterId: "char_2",
+          purpose: Purpose.ascension,
+          upperLevel: 80,
+          materialId: "mat_c2",
+        ),
+      ]);
+
+      final result = await db.getCharacterMaterialBookmarkLevelRanges("char_1");
+
+      expect(result[Purpose.ascension]!.maxUpperLevel, 40);
+    });
+  });
+
+  group("getWeaponMaterialBookmarkLevelRanges", () {
+    test("returns empty map when no bookmarks", () async {
+      final result = await db.getWeaponMaterialBookmarkLevelRanges("weapon_1");
+      expect(result, isEmpty);
+    });
+
+    test("returns single weapon bookmark range correctly", () async {
+      await db.addMaterialBookmarks([
+        _makeWeaponBookmark(
+          characterId: "char_1",
+          weaponId: "weapon_1",
+          upperLevel: 50,
+        ),
+      ]);
+
+      final result = await db.getWeaponMaterialBookmarkLevelRanges("weapon_1");
+
+      expect(result, hasLength(1));
+      expect(result[Purpose.ascension]!.minUpperLevel, 50);
+      expect(result[Purpose.ascension]!.maxUpperLevel, 50);
+    });
+
+    test("aggregates across multiple characters sharing the same weapon",
+        () async {
+      await db.addMaterialBookmarks([
+        _makeWeaponBookmark(
+          characterId: "char_1",
+          weaponId: "weapon_1",
+          upperLevel: 40,
+          materialId: "wmat_a",
+        ),
+        _makeWeaponBookmark(
+          characterId: "char_2",
+          weaponId: "weapon_1",
+          upperLevel: 70,
+          materialId: "wmat_b",
+        ),
+      ]);
+
+      final result = await db.getWeaponMaterialBookmarkLevelRanges("weapon_1");
+
+      expect(result[Purpose.ascension]!.minUpperLevel, 40);
+      expect(result[Purpose.ascension]!.maxUpperLevel, 70);
+    });
+
+    test("does not include character bookmarks", () async {
+      await db.addMaterialBookmarks([
+        _makeCharacterBookmark(
+          characterId: "char_1",
+          purpose: Purpose.ascension,
+          upperLevel: 80,
+          materialId: "char_mat",
+        ),
+        _makeWeaponBookmark(
+          characterId: "char_1",
+          weaponId: "weapon_1",
+          upperLevel: 50,
+          materialId: "weapon_mat",
+        ),
+      ]);
+
+      final result = await db.getWeaponMaterialBookmarkLevelRanges("weapon_1");
+
+      expect(result, hasLength(1));
+      expect(result[Purpose.ascension]!.maxUpperLevel, 50);
+    });
+
+    test("does not include bookmarks for other weapons", () async {
+      await db.addMaterialBookmarks([
+        _makeWeaponBookmark(
+          characterId: "char_1",
+          weaponId: "weapon_1",
+          upperLevel: 50,
+          materialId: "wmat_1",
+        ),
+        _makeWeaponBookmark(
+          characterId: "char_1",
+          weaponId: "weapon_2",
+          upperLevel: 80,
+          materialId: "wmat_2",
+        ),
+      ]);
+
+      final result = await db.getWeaponMaterialBookmarkLevelRanges("weapon_1");
+
+      expect(result[Purpose.ascension]!.maxUpperLevel, 50);
+    });
+  });
+}

--- a/test/drift/db/bookmark_db_extension_test.dart
+++ b/test/drift/db/bookmark_db_extension_test.dart
@@ -25,7 +25,7 @@ void main() {
     return MaterialBookmarkInsertable(
       characterId: characterId,
       weaponId: null,
-      materialId: materialId ?? "mat_$upperLevel",
+      materialId: materialId,
       quantity: 1,
       upperLevel: upperLevel,
       purposeType: purpose,
@@ -41,7 +41,7 @@ void main() {
     return MaterialBookmarkInsertable(
       characterId: characterId,
       weaponId: weaponId,
-      materialId: materialId ?? "wmat_$upperLevel",
+      materialId: materialId,
       quantity: 1,
       upperLevel: upperLevel,
       purposeType: Purpose.ascension,
@@ -118,10 +118,8 @@ void main() {
       final result = await db.getCharacterMaterialBookmarkLevelRanges("char_1");
 
       expect(result, hasLength(2));
-      expect(result[Purpose.ascension]!.minUpperLevel, 40);
-      expect(result[Purpose.ascension]!.maxUpperLevel, 40);
-      expect(result[Purpose.normalAttack]!.minUpperLevel, 6);
-      expect(result[Purpose.normalAttack]!.maxUpperLevel, 6);
+      expect(result[Purpose.ascension], (minUpperLevel: 40, maxUpperLevel: 40));
+      expect(result[Purpose.normalAttack], (minUpperLevel: 6, maxUpperLevel: 6));
     });
 
     test("does not include weapon bookmarks", () async {

--- a/test/drift/db/bookmark_db_extension_test.dart
+++ b/test/drift/db/bookmark_db_extension_test.dart
@@ -16,7 +16,7 @@ void main() {
     await db.close();
   });
 
-  MaterialBookmarkInsertable _makeCharacterBookmark({
+  MaterialBookmarkInsertable makeCharacterBookmark({
     required String characterId,
     required Purpose purpose,
     required int upperLevel,
@@ -32,7 +32,7 @@ void main() {
     );
   }
 
-  MaterialBookmarkInsertable _makeWeaponBookmark({
+  MaterialBookmarkInsertable makeWeaponBookmark({
     required String characterId,
     required String weaponId,
     required int upperLevel,
@@ -56,7 +56,7 @@ void main() {
 
     test("returns single bookmark range correctly", () async {
       await db.addMaterialBookmarks([
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.ascension,
           upperLevel: 40,
@@ -73,19 +73,19 @@ void main() {
     test("aggregates min/max across multiple bookmarks for same purpose",
         () async {
       await db.addMaterialBookmarks([
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.ascension,
           upperLevel: 20,
           materialId: "mat_a",
         ),
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.ascension,
           upperLevel: 40,
           materialId: "mat_b",
         ),
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.ascension,
           upperLevel: 60,
@@ -101,13 +101,13 @@ void main() {
 
     test("returns separate ranges per purpose", () async {
       await db.addMaterialBookmarks([
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.ascension,
           upperLevel: 40,
           materialId: "mat_asc",
         ),
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.normalAttack,
           upperLevel: 6,
@@ -126,13 +126,13 @@ void main() {
 
     test("does not include weapon bookmarks", () async {
       await db.addMaterialBookmarks([
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.ascension,
           upperLevel: 40,
           materialId: "char_mat",
         ),
-        _makeWeaponBookmark(
+        makeWeaponBookmark(
           characterId: "char_1",
           weaponId: "weapon_1",
           upperLevel: 70,
@@ -148,13 +148,13 @@ void main() {
 
     test("does not include bookmarks for other characters", () async {
       await db.addMaterialBookmarks([
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.ascension,
           upperLevel: 40,
           materialId: "mat_c1",
         ),
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_2",
           purpose: Purpose.ascension,
           upperLevel: 80,
@@ -176,7 +176,7 @@ void main() {
 
     test("returns single weapon bookmark range correctly", () async {
       await db.addMaterialBookmarks([
-        _makeWeaponBookmark(
+        makeWeaponBookmark(
           characterId: "char_1",
           weaponId: "weapon_1",
           upperLevel: 50,
@@ -193,13 +193,13 @@ void main() {
     test("aggregates across multiple characters sharing the same weapon",
         () async {
       await db.addMaterialBookmarks([
-        _makeWeaponBookmark(
+        makeWeaponBookmark(
           characterId: "char_1",
           weaponId: "weapon_1",
           upperLevel: 40,
           materialId: "wmat_a",
         ),
-        _makeWeaponBookmark(
+        makeWeaponBookmark(
           characterId: "char_2",
           weaponId: "weapon_1",
           upperLevel: 70,
@@ -215,13 +215,13 @@ void main() {
 
     test("does not include character bookmarks", () async {
       await db.addMaterialBookmarks([
-        _makeCharacterBookmark(
+        makeCharacterBookmark(
           characterId: "char_1",
           purpose: Purpose.ascension,
           upperLevel: 80,
           materialId: "char_mat",
         ),
-        _makeWeaponBookmark(
+        makeWeaponBookmark(
           characterId: "char_1",
           weaponId: "weapon_1",
           upperLevel: 50,
@@ -237,13 +237,13 @@ void main() {
 
     test("does not include bookmarks for other weapons", () async {
       await db.addMaterialBookmarks([
-        _makeWeaponBookmark(
+        makeWeaponBookmark(
           characterId: "char_1",
           weaponId: "weapon_1",
           upperLevel: 50,
           materialId: "wmat_1",
         ),
-        _makeWeaponBookmark(
+        makeWeaponBookmark(
           characterId: "char_1",
           weaponId: "weapon_2",
           upperLevel: 80,

--- a/test/unit/bookmark_slider_init_test.dart
+++ b/test/unit/bookmark_slider_init_test.dart
@@ -1,0 +1,141 @@
+import "dart:math";
+
+import "package:flutter_test/flutter_test.dart";
+
+/// Replicates the bookmark-start computation from _CharacterDetailsPageState.init().
+int computeBookmarkStart({
+  required List<int> levelTicks,
+  required int minUpperLevel,
+}) {
+  final index = levelTicks.indexOf(minUpperLevel);
+  return index >= 1 ? levelTicks[index - 1] : 1;
+}
+
+/// Replicates the full slider start computation combining character state
+/// and bookmark ranges.
+int computeSliderStart({
+  required List<int> levelTicks,
+  required int characterCurrentLevel,
+  required int? bookmarkMinUpperLevel,
+}) {
+  if (bookmarkMinUpperLevel == null) {
+    return characterCurrentLevel;
+  }
+  final bookmarkStart = computeBookmarkStart(
+    levelTicks: levelTicks,
+    minUpperLevel: bookmarkMinUpperLevel,
+  );
+  return max(characterCurrentLevel, bookmarkStart);
+}
+
+void main() {
+  // Typical character ascension ticks: 1, 20, 40, 50, 60, 70, 80, 90
+  const characterTicks = [1, 20, 40, 50, 60, 70, 80, 90];
+
+  // Typical talent ticks: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+  const talentTicks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  group("computeBookmarkStart", () {
+    test("returns previous tick for mid-range minUpperLevel", () {
+      // minUpperLevel=40 is at index 2, so start = ticks[1] = 20
+      expect(
+        computeBookmarkStart(levelTicks: characterTicks, minUpperLevel: 40),
+        20,
+      );
+    });
+
+    test("returns 1 when minUpperLevel is the first tick", () {
+      // minUpperLevel=1 is at index 0, fallback to 1
+      expect(
+        computeBookmarkStart(levelTicks: characterTicks, minUpperLevel: 1),
+        1,
+      );
+    });
+
+    test("returns 1 when minUpperLevel is the second tick (20)", () {
+      // minUpperLevel=20 is at index 1, so start = ticks[0] = 1
+      expect(
+        computeBookmarkStart(levelTicks: characterTicks, minUpperLevel: 20),
+        1,
+      );
+    });
+
+    test("returns correct start for last tick", () {
+      // minUpperLevel=90 is at index 7, so start = ticks[6] = 80
+      expect(
+        computeBookmarkStart(levelTicks: characterTicks, minUpperLevel: 90),
+        80,
+      );
+    });
+
+    test("works for talent ticks", () {
+      // minUpperLevel=6 is at index 5, so start = ticks[4] = 5
+      expect(
+        computeBookmarkStart(levelTicks: talentTicks, minUpperLevel: 6),
+        5,
+      );
+    });
+  });
+
+  group("computeSliderStart (with character state)", () {
+    test("uses characterCurrentLevel when no bookmarks", () {
+      expect(
+        computeSliderStart(
+          levelTicks: characterTicks,
+          characterCurrentLevel: 40,
+          bookmarkMinUpperLevel: null,
+        ),
+        40,
+      );
+    });
+
+    test("uses bookmarkStart when character is at level 1", () {
+      // bookmark minUpperLevel=40 → bookmarkStart=20; character=1; max(1,20)=20
+      expect(
+        computeSliderStart(
+          levelTicks: characterTicks,
+          characterCurrentLevel: 1,
+          bookmarkMinUpperLevel: 40,
+        ),
+        20,
+      );
+    });
+
+    test("uses characterCurrentLevel when it exceeds bookmarkStart", () {
+      // bookmark minUpperLevel=40 → bookmarkStart=20; character=50; max(50,20)=50
+      expect(
+        computeSliderStart(
+          levelTicks: characterTicks,
+          characterCurrentLevel: 50,
+          bookmarkMinUpperLevel: 40,
+        ),
+        50,
+      );
+    });
+
+    test("uses bookmarkStart when it matches characterCurrentLevel", () {
+      // bookmark minUpperLevel=40 → bookmarkStart=20; character=20; max(20,20)=20
+      expect(
+        computeSliderStart(
+          levelTicks: characterTicks,
+          characterCurrentLevel: 20,
+          bookmarkMinUpperLevel: 40,
+        ),
+        20,
+      );
+    });
+
+    test("returns 1 when bookmark starts at first tick and character is at 1",
+        () {
+      // bookmark minUpperLevel=1 → bookmarkStart=1; character=1; max(1,1)=1
+      expect(
+        computeSliderStart(
+          levelTicks: characterTicks,
+          characterCurrentLevel: 1,
+          bookmarkMinUpperLevel: 1,
+        ),
+        1,
+      );
+    });
+  });
+}

--- a/test/unit/bookmark_slider_init_test.dart
+++ b/test/unit/bookmark_slider_init_test.dart
@@ -1,5 +1,3 @@
-import "dart:math";
-
 import "package:flutter_test/flutter_test.dart";
 
 /// Replicates the bookmark-start computation from _CharacterDetailsPageState.init().
@@ -11,8 +9,8 @@ int computeBookmarkStart({
   return index >= 1 ? levelTicks[index - 1] : 1;
 }
 
-/// Replicates the full slider start computation combining character state
-/// and bookmark ranges.
+/// Replicates the full slider start computation.
+/// When bookmarks exist, characterCurrentLevel is ignored.
 int computeSliderStart({
   required List<int> levelTicks,
   required int characterCurrentLevel,
@@ -21,11 +19,10 @@ int computeSliderStart({
   if (bookmarkMinUpperLevel == null) {
     return characterCurrentLevel;
   }
-  final bookmarkStart = computeBookmarkStart(
+  return computeBookmarkStart(
     levelTicks: levelTicks,
     minUpperLevel: bookmarkMinUpperLevel,
   );
-  return max(characterCurrentLevel, bookmarkStart);
 }
 
 void main() {
@@ -89,49 +86,36 @@ void main() {
       );
     });
 
-    test("uses bookmarkStart when character is at level 1", () {
-      // bookmark minUpperLevel=40 → bookmarkStart=20; character=1; max(1,20)=20
-      expect(
-        computeSliderStart(
-          levelTicks: characterTicks,
-          characterCurrentLevel: 1,
-          bookmarkMinUpperLevel: 40,
-        ),
-        20,
-      );
-    });
-
-    test("uses characterCurrentLevel when it exceeds bookmarkStart", () {
-      // bookmark minUpperLevel=40 → bookmarkStart=20; character=50; max(50,20)=50
+    test("uses bookmarkStart and ignores characterCurrentLevel when bookmarks exist",
+        () {
+      // bookmark minUpperLevel=40 → bookmarkStart=20; character=50 → ignored
       expect(
         computeSliderStart(
           levelTicks: characterTicks,
           characterCurrentLevel: 50,
           bookmarkMinUpperLevel: 40,
         ),
-        50,
+        20,
       );
     });
 
-    test("uses bookmarkStart when it matches characterCurrentLevel", () {
-      // bookmark minUpperLevel=40 → bookmarkStart=20; character=20; max(20,20)=20
+    test("uses bookmarkStart when character is at level 1", () {
+      // bookmark minUpperLevel=40 → bookmarkStart=20
       expect(
         computeSliderStart(
           levelTicks: characterTicks,
-          characterCurrentLevel: 20,
+          characterCurrentLevel: 1,
           bookmarkMinUpperLevel: 40,
         ),
         20,
       );
     });
 
-    test("returns 1 when bookmark starts at first tick and character is at 1",
-        () {
-      // bookmark minUpperLevel=1 → bookmarkStart=1; character=1; max(1,1)=1
+    test("returns 1 when bookmark minUpperLevel is the first tick", () {
       expect(
         computeSliderStart(
           levelTicks: characterTicks,
-          characterCurrentLevel: 1,
+          characterCurrentLevel: 40,
           bookmarkMinUpperLevel: 1,
         ),
         1,


### PR DESCRIPTION
If material bookmarks exist for a character/weapon, initialize the
slider range to cover the widest bookmarked range instead of always
defaulting to (1, maxLevel). Uses the level tick before the minimum
bookmarked upperLevel as start, and the maximum bookmarked upperLevel
as end. Character state current level takes priority as minimum start.

closes #240 
closes #373 

https://claude.ai/code/session_01S19VjzZnwoe1EDFYiDu9Mq