### PR TITLE
fix: AssetDataに存在しない装備武器でキャラページがクラッシュする問題を修正

### DIFF
--- a/lib/i18n/en.i18n.yaml
+++ b/lib/i18n/en.i18n.yaml
@@ -132,6 +132,7 @@ bookmarksPage:
   allFurnishingsAreCrafted: All furnishings in this set have been crafted.
 characterDetailsPage:
   equippedWeapon: Equipped Weapon
+  unknownWeapon: Unknown
   favoriteFurnishingSets: Favorite Furnishing Sets
 weaponDetailsPage:
   characterToEquip: Character to Equip this Weapon

--- a/lib/i18n/ja.i18n.yaml
+++ b/lib/i18n/ja.i18n.yaml
@@ -129,6 +129,7 @@ bookmarksPage:
   allFurnishingsAreCrafted: すべての調度品が作成済みです
 characterDetailsPage:
   equippedWeapon: 装備中の武器
+  unknownWeapon: 不明
   favoriteFurnishingSets: 好きな調度品セット
 weaponDetailsPage:
   characterToEquip: 武器を装備させるキャラクター

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 531 (265 per locale)
+/// Strings: 533 (266 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -293,6 +293,7 @@ class _Translations$characterDetailsPage$en extends Translations$characterDetail
 
 	// Translations
 	@override String get equippedWeapon => 'Equipped Weapon';
+	@override String get unknownWeapon => 'Unknown';
 	@override String get favoriteFurnishingSets => 'Favorite Furnishing Sets';
 }
 
@@ -763,6 +764,7 @@ extension on TranslationsEn {
 			'bookmarksPage.furnishings' => 'Furnishings',
 			'bookmarksPage.allFurnishingsAreCrafted' => 'All furnishings in this set have been crafted.',
 			'characterDetailsPage.equippedWeapon' => 'Equipped Weapon',
+			'characterDetailsPage.unknownWeapon' => 'Unknown',
 			'characterDetailsPage.favoriteFurnishingSets' => 'Favorite Furnishing Sets',
 			'weaponDetailsPage.characterToEquip' => 'Character to Equip this Weapon',
 			'weaponDetailsPage.skillEffect' => 'Skill Effect',

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -471,6 +471,9 @@ class Translations$characterDetailsPage$ja {
 	/// ja: '装備中の武器'
 	String get equippedWeapon => '装備中の武器';
 
+	/// ja: '不明'
+	String get unknownWeapon => '不明';
+
 	/// ja: '好きな調度品セット'
 	String get favoriteFurnishingSets => '好きな調度品セット';
 }
@@ -1242,6 +1245,7 @@ extension on Translations {
 			'bookmarksPage.furnishings' => '調度品',
 			'bookmarksPage.allFurnishingsAreCrafted' => 'すべての調度品が作成済みです',
 			'characterDetailsPage.equippedWeapon' => '装備中の武器',
+			'characterDetailsPage.unknownWeapon' => '不明',
 			'characterDetailsPage.favoriteFurnishingSets' => '好きな調度品セット',
 			'weaponDetailsPage.characterToEquip' => '武器を装備させるキャラクター',
 			'weaponDetailsPage.skillEffect' => 'スキル効果',

--- a/lib/pages/database/characters/character_details.dart
+++ b/lib/pages/database/characters/character_details.dart
@@ -180,6 +180,8 @@ class _CharacterDetailsPageContents extends HookConsumerWidget {
       });
     }
 
+    final equippedWeapon = assetData.weapons[state.value.equippedWeaponId];
+
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -313,19 +315,23 @@ class _CharacterDetailsPageContents extends HookConsumerWidget {
                   FullWidth(
                     child: ListTile(
                       title: Text(tr.characterDetailsPage.equippedWeapon),
-                      subtitle: Text(assetData.weapons[state.value.equippedWeaponId]!.name.localized),
-                      leading: Image.file(
-                        assetData.weapons[state.value.equippedWeaponId]!.getImageFile(assetData.assetDir),
-                        width: 50,
-                        height: 50,
-                      ),
-                      trailing: const Icon(Symbols.chevron_right),
-                      onTap: () {
-                        WeaponDetailsRoute(
-                          id: state.value.equippedWeaponId!,
-                          initialSelectedCharacter: variant.value.id,
-                        ).push(context);
-                      },
+                      subtitle: Text(equippedWeapon?.name.localized ?? tr.characterDetailsPage.unknownWeapon),
+                      leading: equippedWeapon != null
+                          ? Image.file(
+                              equippedWeapon.getImageFile(assetData.assetDir),
+                              width: 50,
+                              height: 50,
+                            )
+                          : const Icon(Symbols.question_mark, size: 38),
+                      trailing: equippedWeapon != null ? const Icon(Symbols.chevron_right) : null,
+                      onTap: equippedWeapon != null
+                          ? () {
+                              WeaponDetailsRoute(
+                                id: state.value.equippedWeaponId!,
+                                initialSelectedCharacter: variant.value.id,
+                              ).push(context);
+                            }
+                          : null,
                     ),
                   ),
 


### PR DESCRIPTION
## 概要
装備中の武器IDが `AssetData` に存在しない場合にnull参照でキャラページがクラッシュする問題を修正しました。

装備中の武器が見つからない場合、リーディングアイコンを `question_mark` に、武器名を「不明」と表示し、詳細ページへの遷移も無効化しています。

Closes #452

Generated with [Claude Code](https://claude.ai/code)